### PR TITLE
feat: implement paper submission backend with approval workflow

### DIFF
--- a/backend/app/Enums/PaperStatus.php
+++ b/backend/app/Enums/PaperStatus.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Enums;
+
+enum PaperStatus: string
+{
+    case DRAFT = 'draft';
+    case SUBMITTED = 'submitted';
+    case UNDER_REVIEW = 'under_review';
+    case APPROVED = 'approved';
+    case REJECTED = 'rejected';
+
+    public function label(): string
+    {
+        return match($this) {
+            self::DRAFT => 'Draft',
+            self::SUBMITTED => 'Submitted',
+            self::UNDER_REVIEW => 'Under Review',
+            self::APPROVED => 'Approved',
+            self::REJECTED => 'Rejected',
+        };
+    }
+
+    public function color(): string
+    {
+        return match($this) {
+            self::DRAFT => 'gray',
+            self::SUBMITTED => 'blue',
+            self::UNDER_REVIEW => 'yellow',
+            self::APPROVED => 'green',
+            self::REJECTED => 'red',
+        };
+    }
+
+    public function isEditable(): bool
+    {
+        return match($this) {
+            self::DRAFT => true,
+            self::SUBMITTED => false,
+            self::UNDER_REVIEW => false,
+            self::APPROVED => false,
+            self::REJECTED => false,
+        };
+    }
+
+    public function isSubmittable(): bool
+    {
+        return $this === self::DRAFT;
+    }
+}

--- a/backend/app/Http/Controllers/Api/DashboardController.php
+++ b/backend/app/Http/Controllers/Api/DashboardController.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Project;
+use App\Models\Task;
+use App\Models\Notification;
+use App\Models\ActivityLog;
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    /**
+     * Get dashboard statistics for the authenticated user
+     * GET /api/v1/dashboard/stats
+     */
+    public function stats(Request $request)
+    {
+        $user = $request->user();
+
+        // Get project IDs where user is a member or supervisor
+        $projectIds = $user->projectsAsMember()->pluck('projects.id')->toArray();
+        $supervisedIds = $user->supervisedProjects()->pluck('id')->toArray();
+        $allProjectIds = array_unique(array_merge($projectIds, $supervisedIds));
+
+        // Get task counts
+        $totalTasks = Task::whereIn('project_id', $allProjectIds)->count();
+        $completedTasks = Task::whereIn('project_id', $allProjectIds)
+            ->where('status', 'completed')
+            ->count();
+        $pendingTasks = Task::whereIn('project_id', $allProjectIds)
+            ->where('status', 'pending')
+            ->count();
+        $inProgressTasks = Task::whereIn('project_id', $allProjectIds)
+            ->where('status', 'in_progress')
+            ->count();
+
+        // Get project counts
+        $totalProjects = count($allProjectIds);
+        $activeProjects = Project::whereIn('id', $allProjectIds)
+            ->whereIn('status', ['planning', 'in_progress'])
+            ->count();
+        $completedProjects = Project::whereIn('id', $allProjectIds)
+            ->where('status', 'completed')
+            ->count();
+
+        // Get paper counts
+        $totalPapers = $user->papers()->count();
+        $verifiedPapers = $user->papers()->where('is_verified', true)->count();
+        $pendingPapers = $user->papers()->where('status', 'pending')->count();
+
+        // Get unread notification count
+        $unreadNotifications = $user->unreadNotifications()->count();
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'projects' => [
+                    'total' => $totalProjects,
+                    'active' => $activeProjects,
+                    'completed' => $completedProjects,
+                ],
+                'tasks' => [
+                    'total' => $totalTasks,
+                    'completed' => $completedTasks,
+                    'pending' => $pendingTasks,
+                    'in_progress' => $inProgressTasks,
+                ],
+                'papers' => [
+                    'total' => $totalPapers,
+                    'verified' => $verifiedPapers,
+                    'pending' => $pendingPapers,
+                ],
+                'notifications' => [
+                    'unread' => $unreadNotifications,
+                ],
+            ]
+        ]);
+    }
+
+    /**
+     * Get recent activity for the authenticated user
+     * GET /api/v1/dashboard/recent-activity
+     */
+    public function recentActivity(Request $request)
+    {
+        $user = $request->user();
+
+        // Get recent activity logs
+        $activities = ActivityLog::where('user_id', $user->id)
+            ->orderBy('created_at', 'desc')
+            ->limit(10)
+            ->get();
+
+        // Also get recent notifications
+        $notifications = Notification::where('user_id', $user->id)
+            ->latest()
+            ->limit(5)
+            ->get();
+
+        // Combine and format
+        $activityFeed = [];
+
+        foreach ($activities as $activity) {
+            $activityFeed[] = [
+                'type' => 'activity',
+                'action' => $activity->action,
+                'entity_type' => $activity->entity_type,
+                'message' => $this->formatActivityMessage($activity),
+                'created_at' => $activity->created_at->toISOString(),
+            ];
+        }
+
+        foreach ($notifications as $notification) {
+            $activityFeed[] = [
+                'type' => 'notification',
+                'id' => $notification->id,
+                'message' => $notification->message,
+                'is_read' => $notification->is_read,
+                'link' => $notification->link,
+                'created_at' => $notification->created_at->toISOString(),
+            ];
+        }
+
+        // Sort by created_at descending
+        usort($activityFeed, function ($a, $b) {
+            return strtotime($b['created_at']) - strtotime($a['created_at']);
+        });
+
+        // Limit to 10 items
+        $activityFeed = array_slice($activityFeed, 0, 10);
+
+        return response()->json([
+            'success' => true,
+            'data' => $activityFeed,
+        ]);
+    }
+
+    /**
+     * Format activity message
+     */
+    private function formatActivityMessage($activity)
+    {
+        $actionMap = [
+            'created' => 'created a new',
+            'updated' => 'updated',
+            'deleted' => 'deleted',
+            'viewed' => 'viewed',
+            'uploaded' => 'uploaded',
+            'assigned' => 'assigned',
+            'completed' => 'completed',
+        ];
+
+        $action = $actionMap[$activity->action] ?? $activity->action;
+        $entity = str_replace('_', ' ', $activity->entity_type);
+
+        return "You {$action} {$entity}";
+    }
+}

--- a/backend/app/Http/Controllers/Api/NotificationController.php
+++ b/backend/app/Http/Controllers/Api/NotificationController.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Notification;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    /**
+     * Get all notifications for the authenticated user
+     * GET /api/v1/dashboard/notifications
+     */
+    public function index(Request $request)
+    {
+        $user = $request->user();
+
+        $query = Notification::where('user_id', $user->id)
+            ->with('sender');
+
+        if ($request->has('filter')) {
+            if ($request->filter === 'unread') {
+                $query->unread();
+            } elseif ($request->filter === 'read') {
+                $query->read();
+            }
+        }
+
+        $notifications = $query->latest()->paginate(20);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Notifications retrieved successfully',
+            'data' => $notifications,
+        ]);
+    }
+
+    /**
+     * Get notification counts
+     * GET /api/v1/dashboard/notifications/count
+     */
+    public function count(Request $request)
+    {
+        $user = $request->user();
+
+        $unread = $user->unreadNotifications()->count();
+        $total = $user->notifications()->count();
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'unread' => $unread,
+                'total' => $total,
+            ],
+        ]);
+    }
+
+    /**
+     * Mark a notification as read
+     * PUT /api/v1/dashboard/notifications/{id}/read
+     */
+    public function markAsRead(Request $request, $id)
+    {
+        $user = $request->user();
+
+        $notification = Notification::where('user_id', $user->id)
+            ->findOrFail($id);
+
+        $notification->markAsRead();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Notification marked as read',
+            'data' => $notification,
+        ]);
+    }
+
+    /**
+     * Mark all notifications as read
+     * PUT /api/v1/dashboard/notifications/mark-all-read
+     */
+    public function markAllAsRead(Request $request)
+    {
+        $user = $request->user();
+
+        $count = $user->unreadNotifications()->update([
+            'is_read' => true,
+            'read_at' => now(),
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'message' => "{$count} notifications marked as read",
+            'data' => [
+                'marked_count' => $count,
+            ],
+        ]);
+    }
+
+    /**
+     * Delete a notification
+     * DELETE /api/v1/dashboard/notifications/{id}
+     */
+    public function destroy(Request $request, $id)
+    {
+        $user = $request->user();
+
+        $notification = Notification::where('user_id', $user->id)
+            ->findOrFail($id);
+
+        $notification->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Notification deleted successfully',
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/PaperController.php
+++ b/backend/app/Http/Controllers/Api/PaperController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ResearchPaper;
+use Illuminate\Http\Request;
+
+class PaperController extends Controller
+{
+    /**
+     * Get all papers for the authenticated user
+     * GET /api/v1/dashboard/papers
+     */
+    public function index(Request $request)
+    {
+        $user = $request->user();
+
+        $papers = ResearchPaper::where('uploaded_by', $user->id)
+            ->orWhereHas('authors', function ($q) use ($user) {
+                $q->where('user_id', $user->id);
+            })
+            ->with(['category', 'researchArea', 'uploadedBy'])
+            ->latest();
+
+        // Apply filters
+        if ($request->has('status')) {
+            $papers->where('status', $request->status);
+        }
+
+        if ($request->has('category_id')) {
+            $papers->where('category_id', $request->category_id);
+        }
+
+        if ($request->has('search')) {
+            $search = $request->search;
+            $papers->where(function ($q) use ($search) {
+                $q->where('title', 'like', "%{$search}%")
+                  ->orWhere('abstract', 'like', "%{$search}%");
+            });
+        }
+
+        $papers = $papers->paginate(10);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Papers retrieved successfully',
+            'data' => $papers,
+        ]);
+    }
+
+    /**
+     * Get paper statistics
+     * GET /api/v1/dashboard/papers/stats
+     */
+    public function stats(Request $request)
+    {
+        $user = $request->user();
+
+        $stats = [
+            'total' => $user->papers()->count(),
+            'verified' => $user->papers()->where('is_verified', true)->count(),
+            'pending' => $user->papers()->where('status', 'pending')->count(),
+            'approved' => $user->papers()->where('status', 'approved')->count(),
+            'rejected' => $user->papers()->where('status', 'rejected')->count(),
+            'total_views' => $user->papers()->sum('views'),
+            'total_downloads' => $user->papers()->sum('downloads'),
+            'recent' => $user->papers()
+                ->latest()
+                ->limit(5)
+                ->get(['id', 'title', 'status', 'created_at']),
+        ];
+
+        return response()->json([
+            'success' => true,
+            'data' => $stats,
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/PaperSubmissionController.php
+++ b/backend/app/Http/Controllers/Api/PaperSubmissionController.php
@@ -1,0 +1,499 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ResearchPaper;
+use App\Http\Requests\StorePaperRequest;
+use App\Http\Requests\UpdatePaperRequest;
+use App\Services\GoogleScholarService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class PaperSubmissionController extends Controller
+{
+    protected $scholarService;
+
+    public function __construct(GoogleScholarService $scholarService)
+    {
+        $this->scholarService = $scholarService;
+    }
+
+    /**
+     * Get all papers for the authenticated user (with filters)
+     * GET /api/v1/submissions
+     */
+    public function index(Request $request)
+    {
+        $user = $request->user();
+
+        $query = ResearchPaper::with([
+            'category', 
+            'researchArea', 
+            'department',
+            'uploadedBy',
+            'authors',
+            'reviewer'
+        ])->forUser($user->id);
+
+        // Filter by submission status
+        if ($request->has('status')) {
+            $query->where('submission_status', $request->status);
+        }
+
+        // Filter by search
+        if ($request->has('search')) {
+            $search = $request->search;
+            $query->where(function ($q) use ($search) {
+                $q->where('title', 'LIKE', "%{$search}%")
+                  ->orWhere('abstract', 'LIKE', "%{$search}%");
+            });
+        }
+
+        $papers = $query->latest()->paginate($request->per_page ?? 10);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Papers retrieved successfully',
+            'data' => $papers,
+        ]);
+    }
+
+    /**
+     * Create a new paper draft
+     * POST /api/v1/submissions
+     */
+    public function store(StorePaperRequest $request)
+    {
+        $user = $request->user();
+
+        $validated = $request->validated();
+
+        // Set default status to draft
+        $paper = ResearchPaper::create([
+            'title' => $validated['title'],
+            'abstract' => $validated['abstract'],
+            'keywords' => $validated['keywords'] ?? null,
+            'research_area' => $validated['research_area'] ?? null,
+            'category' => $validated['category'] ?? null,
+            'authors' => $validated['authors'] ?? null,
+            'google_scholar_url' => $validated['google_scholar_url'] ?? null,
+            'doi' => $validated['doi'] ?? null,
+            'publication_year' => $validated['publication_year'] ?? null,
+            'research_area_id' => $validated['research_area_id'] ?? null,
+            'category_id' => $validated['category_id'] ?? null,
+            'department_id' => $validated['department_id'] ?? null,
+            'uploaded_by' => $user->id,
+            'submission_status' => 'draft',
+            'status' => 'pending',
+            'is_verified' => false,
+        ]);
+
+        // Add the user as an author if not already
+        $paper->authors()->syncWithoutDetaching([$user->id]);
+
+        // Log activity
+        $this->logActivity($user->id, 'created', $paper->id);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Paper draft created successfully',
+            'data' => $paper->load(['category', 'researchArea', 'department', 'uploadedBy']),
+        ], 201);
+    }
+
+    /**
+     * Get a single paper
+     * GET /api/v1/submissions/{id}
+     */
+    public function show(Request $request, $id)
+    {
+        $user = $request->user();
+
+        $paper = ResearchPaper::with([
+            'category', 
+            'researchArea', 
+            'department',
+            'uploadedBy',
+            'authors',
+            'reviewer',
+            'comments'
+        ])->findOrFail($id);
+
+        // Check if user has access
+        if (!$this->canAccess($user, $paper)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You do not have permission to view this paper',
+            ], 403);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data' => $paper,
+        ]);
+    }
+
+    /**
+     * Update a paper draft
+     * PUT /api/v1/submissions/{id}
+     */
+    public function update(UpdatePaperRequest $request, $id)
+    {
+        $user = $request->user();
+
+        $paper = ResearchPaper::findOrFail($id);
+
+        // Check if user can edit
+        if (!$this->canEdit($user, $paper)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You do not have permission to edit this paper',
+            ], 403);
+        }
+
+        // Check if paper is editable (only drafts can be edited)
+        if (!$paper->isEditable()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'This paper cannot be edited. Only drafts are editable.',
+            ], 422);
+        }
+
+        $validated = $request->validated();
+
+        $paper->update($validated);
+
+        // Log activity
+        $this->logActivity($user->id, 'updated', $paper->id);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Paper updated successfully',
+            'data' => $paper->load(['category', 'researchArea', 'department', 'uploadedBy']),
+        ]);
+    }
+
+    /**
+     * Submit a paper for approval
+     * POST /api/v1/submissions/{id}/submit
+     */
+    public function submit(Request $request, $id)
+    {
+        $user = $request->user();
+
+        $paper = ResearchPaper::findOrFail($id);
+
+        // Check if user owns the paper
+        if ($paper->uploaded_by !== $user->id) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You do not have permission to submit this paper',
+            ], 403);
+        }
+
+        // Check if paper is submittable
+        if (!$paper->isSubmittable()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'This paper cannot be submitted. Only drafts can be submitted.',
+            ], 422);
+        }
+
+        // Check if paper is complete
+        if (!$paper->isComplete()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Paper is incomplete. Please fill in all required fields before submitting.',
+                'errors' => [
+                    'required_fields' => ['title', 'abstract', 'authors']
+                ],
+            ], 422);
+        }
+
+        // Submit the paper
+        if ($paper->submit()) {
+            // Create notification for admins
+            $this->createNotification($paper, 'submitted');
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Paper submitted successfully for approval',
+                'data' => $paper->fresh(),
+            ]);
+        }
+
+        return response()->json([
+            'success' => false,
+            'message' => 'Failed to submit paper',
+        ], 500);
+    }
+
+    /**
+     * Get papers for review (Admin only)
+     * GET /api/v1/submissions/review
+     */
+    public function reviewIndex(Request $request)
+    {
+        $user = $request->user();
+
+        // Check if user is admin
+        if (!$user->isAdmin()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Only administrators can access this endpoint',
+            ], 403);
+        }
+
+        $query = ResearchPaper::with([
+            'category', 
+            'researchArea', 
+            'department',
+            'uploadedBy',
+            'authors'
+        ])->needsReview();
+
+        // Filter by status
+        if ($request->has('status')) {
+            $query->where('submission_status', $request->status);
+        }
+
+        $papers = $query->latest('submitted_at')->paginate($request->per_page ?? 10);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Papers for review retrieved successfully',
+            'data' => $papers,
+        ]);
+    }
+
+    /**
+     * Approve a paper (Admin only)
+     * POST /api/v1/submissions/{id}/approve
+     */
+    public function approve(Request $request, $id)
+    {
+        $user = $request->user();
+
+        // Check if user is admin
+        if (!$user->isAdmin()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Only administrators can approve papers',
+            ], 403);
+        }
+
+        $paper = ResearchPaper::findOrFail($id);
+
+        $validated = $request->validate([
+            'reviewer_notes' => 'nullable|string|max:1000',
+        ]);
+
+        if ($paper->approve($user->id, $validated['reviewer_notes'] ?? null)) {
+            // Create notification for author
+            $this->createNotification($paper, 'approved');
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Paper approved successfully',
+                'data' => $paper->fresh(),
+            ]);
+        }
+
+        return response()->json([
+            'success' => false,
+            'message' => 'This paper cannot be approved',
+        ], 422);
+    }
+
+    /**
+     * Reject a paper (Admin only)
+     * POST /api/v1/submissions/{id}/reject
+     */
+    public function reject(Request $request, $id)
+    {
+        $user = $request->user();
+
+        // Check if user is admin
+        if (!$user->isAdmin()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Only administrators can reject papers',
+            ], 403);
+        }
+
+        $paper = ResearchPaper::findOrFail($id);
+
+        $validated = $request->validate([
+            'rejection_reason' => 'required|string|min:10|max:500',
+            'reviewer_notes' => 'nullable|string|max:1000',
+        ]);
+
+        if ($paper->reject($user->id, $validated['rejection_reason'], $validated['reviewer_notes'] ?? null)) {
+            // Create notification for author
+            $this->createNotification($paper, 'rejected');
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Paper rejected successfully',
+                'data' => $paper->fresh(),
+            ]);
+        }
+
+        return response()->json([
+            'success' => false,
+            'message' => 'This paper cannot be rejected',
+        ], 422);
+    }
+
+    /**
+     * Return paper to draft (Admin only)
+     * POST /api/v1/submissions/{id}/return-to-draft
+     */
+    public function returnToDraft(Request $request, $id)
+    {
+        $user = $request->user();
+
+        // Check if user is admin
+        if (!$user->isAdmin()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Only administrators can perform this action',
+            ], 403);
+        }
+
+        $paper = ResearchPaper::findOrFail($id);
+
+        if ($paper->returnToDraft()) {
+            // Create notification for author
+            $this->createNotification($paper, 'returned');
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Paper returned to draft successfully',
+                'data' => $paper->fresh(),
+            ]);
+        }
+
+        return response()->json([
+            'success' => false,
+            'message' => 'This paper cannot be returned to draft',
+        ], 422);
+    }
+
+    /**
+     * Delete a paper (only if draft or rejected)
+     * DELETE /api/v1/submissions/{id}
+     */
+    public function destroy(Request $request, $id)
+    {
+        $user = $request->user();
+
+        $paper = ResearchPaper::findOrFail($id);
+
+        // Check if user owns the paper
+        if ($paper->uploaded_by !== $user->id && !$user->isAdmin()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You do not have permission to delete this paper',
+            ], 403);
+        }
+
+        // Check if paper can be deleted (only draft or rejected)
+        if (!$paper->isDraft() && !$paper->isRejected()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Only drafts or rejected papers can be deleted',
+            ], 422);
+        }
+
+        $paper->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Paper deleted successfully',
+        ]);
+    }
+
+    /**
+     * Check if user can access the paper
+     */
+    private function canAccess($user, $paper): bool
+    {
+        // Admin can access all
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        // User can access their own papers
+        if ($paper->uploaded_by === $user->id) {
+            return true;
+        }
+
+        // User can access if they are an author
+        return $paper->authors()->where('user_id', $user->id)->exists();
+    }
+
+    /**
+     * Check if user can edit the paper
+     */
+    private function canEdit($user, $paper): bool
+    {
+        // Only the uploader can edit
+        return $paper->uploaded_by === $user->id;
+    }
+
+    /**
+     * Log activity
+     */
+    private function logActivity(int $userId, string $action, int $paperId): void
+    {
+        // You can implement activity logging here
+        // or use the existing ActivityLog model
+    }
+
+    /**
+     * Create notification
+     */
+    private function createNotification($paper, string $action): void
+    {
+        // Get admin users
+        $admins = \App\Models\User::whereHas('role', function ($q) {
+            $q->whereIn('name', ['sys_admin', 'dept_admin']);
+        })->get();
+
+        $messages = [
+            'submitted' => "New paper '{$paper->title}' has been submitted for approval.",
+            'approved' => "Your paper '{$paper->title}' has been approved.",
+            'rejected' => "Your paper '{$paper->title}' has been rejected.",
+            'returned' => "Your paper '{$paper->title}' has been returned to draft.",
+        ];
+
+        $message = $messages[$action] ?? "Paper '{$paper->title}' has been updated.";
+
+        // Send notifications
+        if ($action === 'submitted') {
+            // Notify admins
+            foreach ($admins as $admin) {
+                \App\Models\Notification::create([
+                    'user_id' => $admin->id,
+                    'sender_id' => $paper->uploaded_by,
+                    'type' => 'paper_submitted',
+                    'message' => $message,
+                    'data' => ['paper_id' => $paper->id],
+                    'link' => '/admin/papers/review',
+                ]);
+            }
+        } else {
+            // Notify author
+            \App\Models\Notification::create([
+                'user_id' => $paper->uploaded_by,
+                'sender_id' => auth()->id(),
+                'type' => 'paper_reviewed',
+                'message' => $message,
+                'data' => ['paper_id' => $paper->id],
+                'link' => '/dashboard/papers/' . $paper->id,
+            ]);
+        }
+    }
+}

--- a/backend/app/Http/Controllers/Api/ProjectController.php
+++ b/backend/app/Http/Controllers/Api/ProjectController.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Project;
+use App\Models\ProjectMember;
+use App\Models\ActivityLog;
+use Illuminate\Http\Request;
+
+class ProjectController extends Controller
+{
+    /**
+     * Get all projects for the authenticated user
+     * GET /api/v1/dashboard/projects
+     */
+    public function index(Request $request)
+    {
+        $user = $request->user();
+
+        // Get projects where user is a member OR supervisor
+        $projects = Project::where(function ($query) use ($user) {
+            $query->whereHas('members', function ($q) use ($user) {
+                $q->where('user_id', $user->id);
+            })->orWhere('supervisor_id', $user->id);
+        })->with([
+            'supervisor',
+            'members.user',
+            'researchArea',
+            'tasks'
+        ]);
+
+        // Apply filters
+        if ($request->has('status')) {
+            $projects->where('status', $request->status);
+        }
+
+        if ($request->has('search')) {
+            $search = $request->search;
+            $projects->where(function ($q) use ($search) {
+                $q->where('title', 'like', "%{$search}%")
+                  ->orWhere('description', 'like', "%{$search}%");
+            });
+        }
+
+        // Order by latest
+        $projects = $projects->latest()->paginate(10);
+
+        // Transform data
+        $projects->getCollection()->transform(function ($project) {
+            return [
+                'id' => $project->id,
+                'title' => $project->title,
+                'description' => $project->description,
+                'status' => $project->status,
+                'status_color' => $project->status_color ?? 'blue',
+                'progress' => $project->progress_pct,
+                'supervisor' => $project->supervisor ? [
+                    'id' => $project->supervisor->id,
+                    'name' => $project->supervisor->full_name,
+                    'email' => $project->supervisor->email,
+                ] : null,
+                'members_count' => $project->members->count(),
+                'tasks_count' => $project->tasks->count(),
+                'completed_tasks' => $project->tasks->where('status', 'completed')->count(),
+                'start_date' => $project->start_date->toDateString(),
+                'deadline' => $project->deadline ? $project->deadline->toDateString() : null,
+                'created_at' => $project->created_at->toISOString(),
+                'updated_at' => $project->updated_at->toISOString(),
+            ];
+        });
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Projects retrieved successfully',
+            'data' => $projects,
+        ]);
+    }
+
+    /**
+     * Get a single project
+     * GET /api/v1/dashboard/projects/{id}
+     */
+    public function show(Request $request, $id)
+    {
+        $user = $request->user();
+
+        $project = Project::with([
+            'supervisor',
+            'members.user',
+            'researchArea',
+            'tasks',
+            'files',
+            'comments.user'
+        ])->findOrFail($id);
+
+        // Check if user has access to this project
+        $isMember = $project->members()->where('user_id', $user->id)->exists();
+        $isSupervisor = $project->supervisor_id === $user->id;
+
+        if (!$isMember && !$isSupervisor) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You do not have access to this project',
+            ], 403);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data' => $project,
+        ]);
+    }
+
+    /**
+     * Create a new project
+     * POST /api/v1/dashboard/projects
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:200',
+            'description' => 'required|string',
+            'research_area_id' => 'required|exists:research_areas,id',
+            'start_date' => 'required|date',
+            'deadline' => 'nullable|date|after:start_date',
+            'is_public' => 'boolean',
+        ]);
+
+        $project = Project::create([
+            'title' => $validated['title'],
+            'description' => $validated['description'],
+            'research_area_id' => $validated['research_area_id'],
+            'created_by' => $request->user()->id,
+            'start_date' => $validated['start_date'],
+            'deadline' => $validated['deadline'] ?? null,
+            'is_public' => $validated['is_public'] ?? false,
+            'status' => 'planning',
+            'progress_pct' => 0,
+        ]);
+
+        // Add creator as a member
+        ProjectMember::create([
+            'project_id' => $project->id,
+            'user_id' => $request->user()->id,
+            'role' => 'admin',
+            'joined_at' => now(),
+            'is_active' => true,
+        ]);
+
+        // Log activity
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'action' => 'created',
+            'entity_type' => 'project',
+            'entity_id' => $project->id,
+            'new_values' => ['title' => $project->title],
+            'ip_address' => $request->ip(),
+            'user_agent' => $request->userAgent(),
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Project created successfully',
+            'data' => $project->load(['supervisor', 'members.user', 'researchArea']),
+        ], 201);
+    }
+}

--- a/backend/app/Http/Controllers/Api/ResearchPaperController.php
+++ b/backend/app/Http/Controllers/Api/ResearchPaperController.php
@@ -4,73 +4,152 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\ResearchPaper;
+use App\Services\GoogleScholarService;
 use Illuminate\Http\Request;
 
 class ResearchPaperController extends Controller
 {
+    protected $scholarService;
+
+    public function __construct(GoogleScholarService $scholarService)
+    {
+        $this->scholarService = $scholarService;
+    }
+
     /**
-     * Get all research papers (with pagination and optional filters)
+     * Get all research papers (with search and filters)
+     * GET /api/v1/papers
+     *
+     * Query Params:
+     * - search: Search by title, abstract, authors, keywords
+     * - category: Filter by category
+     * - research_area: Filter by research area
+     * - status: Filter by status
+     * - per_page: Pagination limit (default: 10)
      */
     public function index(Request $request)
     {
-        $papers = $this->getPlaceholderPapers();
+        $query = ResearchPaper::query()
+            ->with(['category', 'researchArea', 'uploadedBy']);
 
-        // Apply filters to placeholder data
-        if ($request->has('search')) {
-            $search = strtolower($request->search);
-            $papers = array_filter($papers, function ($paper) use ($search) {
-                return strpos(strtolower($paper['title']), $search) !== false ||
-                       strpos(strtolower($paper['abstract']), $search) !== false ||
-                       strpos(strtolower($paper['authors']), $search) !== false;
-            });
-            $papers = array_values($papers);
+        // Apply search filter
+        if ($request->has('search') && !empty($request->search)) {
+            $query->search($request->search);
         }
 
+        // Apply category filter
         if ($request->has('category')) {
-            $category = $request->category;
-            $papers = array_filter($papers, function ($paper) use ($category) {
-                return $paper['category'] === $category;
-            });
-            $papers = array_values($papers);
+            $query->where('category', 'like', "%{$request->category}%");
         }
 
-        if ($request->has('publication_status')) {
-            $status = $request->publication_status;
-            $papers = array_filter($papers, function ($paper) use ($status) {
-                return $paper['publication_status'] === $status;
-            });
-            $papers = array_values($papers);
+        // Apply research area filter
+        if ($request->has('research_area')) {
+            $query->where('research_area', 'like', "%{$request->research_area}%");
         }
+
+        // Apply status filter
+        if ($request->has('status')) {
+            $query->where('status', $request->status);
+        }
+
+        // Order by latest
+        $papers = $query->latest()->paginate($request->per_page ?? 10);
+
+        // Transform response to include Google Scholar links
+        $papers->getCollection()->transform(function ($paper) {
+            return $this->transformPaperWithScholarLinks($paper);
+        });
 
         return response()->json([
             'success' => true,
             'message' => 'Research papers retrieved successfully',
             'data' => $papers,
             'meta' => [
-                'total' => count($papers),
-                'per_page' => 10,
-                'current_page' => 1,
-                'last_page' => 1,
+                'total' => $papers->total(),
+                'per_page' => $papers->perPage(),
+                'current_page' => $papers->currentPage(),
+                'last_page' => $papers->lastPage(),
             ]
         ]);
     }
 
     /**
      * Get a single research paper
+     * GET /api/v1/papers/{id}
      */
     public function show($id)
     {
-        $paper = $this->getPlaceholderPaper($id);
+        $paper = ResearchPaper::with(['category', 'researchArea', 'uploadedBy', 'authors'])
+            ->find($id);
+
+        if (!$paper) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Research paper not found',
+            ], 404);
+        }
+
+        // Increment view count
+        $paper->increment('views');
 
         return response()->json([
             'success' => true,
             'message' => 'Research paper retrieved successfully',
-            'data' => $paper
+            'data' => $this->transformPaperWithScholarLinks($paper),
         ]);
     }
 
     /**
-     * Create a new research paper (placeholder)
+     * Search papers by title (dedicated search endpoint)
+     * GET /api/v1/papers/search
+     *
+     * Query Params:
+     * - q: Search query (required)
+     * - exact: Boolean - if true, search for exact match (default: false)
+     * - per_page: Pagination limit (default: 10)
+     */
+    public function search(Request $request)
+    {
+        $request->validate([
+            'q' => 'required|string|min:1|max:255',
+        ]);
+
+        $query = ResearchPaper::query()
+            ->with(['category', 'researchArea', 'uploadedBy']);
+
+        // If exact match is requested
+        if ($request->boolean('exact')) {
+            $query->searchExact($request->q);
+        } else {
+            // Fuzzy search
+            $query->search($request->q);
+        }
+
+        $papers = $query->latest()->paginate($request->per_page ?? 10);
+
+        // Transform response to include Google Scholar links
+        $papers->getCollection()->transform(function ($paper) {
+            return $this->transformPaperWithScholarLinks($paper);
+        });
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Search results retrieved successfully',  // ← FIXED: Added closing quote
+            'data' => $papers,
+            'meta' => [
+                'query' => $request->q,
+                'exact_match' => $request->boolean('exact'),
+                'total' => $papers->total(),
+                'per_page' => $papers->perPage(),
+                'current_page' => $papers->currentPage(),
+                'last_page' => $papers->lastPage(),
+            ]
+        ]);
+    }
+
+    /**
+     * Create a new research paper
+     * POST /api/v1/papers
      */
     public function store(Request $request)
     {
@@ -89,10 +168,24 @@ class ResearchPaperController extends Controller
             'doi.regex' => 'The DOI format is invalid. Expected format: 10.xxxx/xxxxx',
         ]);
 
+        // Validate Google Scholar URL if provided
+        if (!empty($validated['google_scholar_url'])) {
+            if (!$this->scholarService->isValidScholarUrl($validated['google_scholar_url'])) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Invalid Google Scholar URL',
+                    'errors' => [
+                        'google_scholar_url' => ['The Google Scholar URL must be a valid Google Scholar link.']
+                    ]
+                ], 422);
+            }
+        }
+
+        // Create paper (placeholder - will be replaced with real DB later)
         return response()->json([
             'success' => true,
             'message' => 'Research paper created successfully (placeholder - database integration pending)',
-            'data' => [
+            'data' => $this->transformScholarLinks([
                 'id' => rand(1000, 9999),
                 'title' => $validated['title'],
                 'abstract' => $validated['abstract'],
@@ -109,12 +202,13 @@ class ResearchPaperController extends Controller
                 'downloads' => 0,
                 'created_at' => now()->toISOString(),
                 'updated_at' => now()->toISOString(),
-            ]
+            ])
         ], 201);
     }
 
     /**
-     * Update an existing research paper (placeholder)
+     * Update a research paper
+     * PUT /api/v1/papers/{id}
      */
     public function update(Request $request, $id)
     {
@@ -133,10 +227,23 @@ class ResearchPaperController extends Controller
             'doi.regex' => 'The DOI format is invalid. Expected format: 10.xxxx/xxxxx',
         ]);
 
+        // Validate Google Scholar URL if provided
+        if (!empty($validated['google_scholar_url'])) {
+            if (!$this->scholarService->isValidScholarUrl($validated['google_scholar_url'])) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Invalid Google Scholar URL',
+                    'errors' => [
+                        'google_scholar_url' => ['The Google Scholar URL must be a valid Google Scholar link.']
+                    ]
+                ], 422);
+            }
+        }
+
         return response()->json([
             'success' => true,
             'message' => 'Research paper updated successfully (placeholder - database integration pending)',
-            'data' => [
+            'data' => $this->transformScholarLinks([
                 'id' => (int) $id,
                 'title' => $validated['title'] ?? 'Updated Research Paper',
                 'abstract' => $validated['abstract'] ?? 'Updated abstract',
@@ -148,12 +255,13 @@ class ResearchPaperController extends Controller
                 'doi' => $validated['doi'] ?? null,
                 'publication_status' => $validated['publication_status'] ?? 'draft',
                 'updated_at' => now()->toISOString(),
-            ]
+            ])
         ]);
     }
 
     /**
-     * Delete a research paper (placeholder)
+     * Delete a research paper
+     * DELETE /api/v1/papers/{id}
      */
     public function destroy($id)
     {
@@ -168,40 +276,40 @@ class ResearchPaperController extends Controller
     }
 
     /**
-     * Get a single placeholder paper
+     * Transform a paper array to include Google Scholar links
+     *
+     * @param array $paper
+     * @return array
      */
-    private function getPlaceholderPaper($id)
+    private function transformScholarLinks(array $paper): array
     {
-        $papers = $this->getPlaceholderPapers();
+        $scholarLinks = $this->scholarService->getScholarLinks(
+            $paper['google_scholar_url'] ?? null,
+            $paper['title'] ?? null
+        );
 
-        foreach ($papers as $paper) {
-            if ($paper['id'] == $id) {
-                return $paper;
-            }
-        }
-
-        return [
-            'id' => (int) $id,
-            'title' => 'Sample Research Paper #' . $id,
-            'abstract' => 'This is a placeholder abstract for the research paper. In the actual implementation, this will be populated from the database.',
-            'keywords' => 'laravel, api, research, placeholder',
-            'research_area' => 'Computer Science',
-            'category' => 'Journal Article',
-            'authors' => 'Dr. John Smith, Jane Doe',
-            'google_scholar_url' => 'https://scholar.google.com/citations?user=sample123',
-            'doi' => '10.1234/sample.2024.01.001',
-            'publication_status' => 'published',
-            'status' => 'approved',
-            'is_verified' => true,
-            'views' => rand(10, 1000),
-            'downloads' => rand(5, 500),
-            'created_at' => now()->subDays(rand(1, 30))->toISOString(),
-            'updated_at' => now()->toISOString(),
-        ];
+        return array_merge($paper, $scholarLinks);
     }
 
     /**
-     * Get placeholder papers list with Google Scholar URLs and DOIs
+     * Transform a paper model to include Google Scholar links
+     *
+     * @param \App\Models\ResearchPaper $paper
+     * @return \App\Models\ResearchPaper
+     */
+    private function transformPaperWithScholarLinks(ResearchPaper $paper): ResearchPaper
+    {
+        $scholarLinks = $paper->getScholarLinks();
+
+        // Add the links as attributes
+        $paper->google_scholar_url = $scholarLinks['google_scholar_url'];
+        $paper->google_scholar_search_url = $scholarLinks['google_scholar_search_url'];
+
+        return $paper;
+    }
+
+    /**
+     * Get placeholder papers (for testing)
      */
     private function getPlaceholderPapers()
     {
@@ -232,7 +340,7 @@ class ResearchPaperController extends Controller
                 'research_area' => 'Natural Language Processing',
                 'category' => 'Conference Paper',
                 'authors' => 'Dr. Emily Brown, Dr. David Wilson',
-                'google_scholar_url' => 'https://scholar.google.com/citations?user=nlpml456',
+                'google_scholar_url' => null,
                 'doi' => '10.1016/j.nlp.2024.02.003',
                 'publication_status' => 'published',
                 'status' => 'approved',
@@ -250,7 +358,7 @@ class ResearchPaperController extends Controller
                 'research_area' => 'Data Mining',
                 'category' => 'Journal Article',
                 'authors' => 'Prof. Robert Taylor, Dr. Lisa Park',
-                'google_scholar_url' => 'https://scholar.google.com/citations?user=datamine789',
+                'google_scholar_url' => null,
                 'doi' => '10.1016/j.dm.2024.03.002',
                 'publication_status' => 'under_review',
                 'status' => 'pending',
@@ -268,7 +376,7 @@ class ResearchPaperController extends Controller
                 'research_area' => 'Cybersecurity',
                 'category' => 'Conference Paper',
                 'authors' => 'Dr. James Martinez, Dr. Anna Kim',
-                'google_scholar_url' => 'https://scholar.google.com/citations?user=iotsec321',
+                'google_scholar_url' => null,
                 'doi' => '10.1016/j.cyber.2024.04.001',
                 'publication_status' => 'submitted',
                 'status' => 'pending',

--- a/backend/app/Http/Controllers/Api/ResearcherController.php
+++ b/backend/app/Http/Controllers/Api/ResearcherController.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class ResearcherController extends Controller
+{
+    /**
+     * Get researcher directory
+     * GET /api/v1/dashboard/researchers
+     */
+    public function index(Request $request)
+    {
+        $query = User::with(['role', 'department']);
+
+        // Apply filters
+        if ($request->has('search')) {
+            $search = $request->search;
+            $query->where(function ($q) use ($search) {
+                $q->where('full_name', 'like', "%{$search}%")
+                  ->orWhere('email', 'like', "%{$search}%")
+                  ->orWhere('institution', 'like', "%{$search}%")
+                  ->orWhere('research_interests', 'like', "%{$search}%");
+            });
+        }
+
+        if ($request->has('role')) {
+            $query->whereHas('role', function ($q) use ($request) {
+                $q->where('name', $request->role);
+            });
+        }
+
+        if ($request->has('department_id')) {
+            $query->where('department_id', $request->department_id);
+        }
+
+        $researchers = $query->paginate(10);
+
+        // Transform data
+        $researchers->getCollection()->transform(function ($user) {
+            return [
+                'id' => $user->id,
+                'full_name' => $user->full_name,
+                'email' => $user->email,
+                'profile_picture' => $user->profile_picture,
+                'institution' => $user->institution,
+                'bio' => $user->bio,
+                'research_interests' => $user->research_interests,
+                'role' => $user->role ? $user->role->display_name : null,
+                'department' => $user->department ? $user->department->name : null,
+                'paper_count' => $user->papers()->count(),
+                'project_count' => $user->projectMemberships()->count() + $user->supervisedProjects()->count(),
+                'followers_count' => $user->followers()->count(),
+                'created_at' => $user->created_at->toISOString(),
+            ];
+        });
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Researchers retrieved successfully',
+            'data' => $researchers,
+        ]);
+    }
+
+    /**
+     * Get a single researcher
+     * GET /api/v1/dashboard/researchers/{id}
+     */
+    public function show($id)
+    {
+        $user = User::with(['role', 'department', 'researchAreas'])
+            ->findOrFail($id);
+
+        $userData = [
+            'id' => $user->id,
+            'full_name' => $user->full_name,
+            'email' => $user->email,
+            'profile_picture' => $user->profile_picture,
+            'institution' => $user->institution,
+            'bio' => $user->bio,
+            'research_interests' => $user->research_interests,
+            'skills' => $user->skills,
+            'role' => $user->role ? $user->role->display_name : null,
+            'department' => $user->department ? $user->department->name : null,
+            'research_areas' => $user->researchAreas->pluck('name'),
+            'paper_count' => $user->papers()->count(),
+            'project_count' => $user->projectMemberships()->count() + $user->supervisedProjects()->count(),
+            'followers_count' => $user->followers()->count(),
+            'following_count' => $user->following()->count(),
+            'created_at' => $user->created_at->toISOString(),
+        ];
+
+        return response()->json([
+            'success' => true,
+            'data' => $userData,
+        ]);
+    }
+
+    /**
+     * Get researchers for autocomplete
+     * GET /api/v1/dashboard/researchers/search
+     */
+    public function search(Request $request)
+    {
+        $query = User::query();
+
+        if ($request->has('query')) {
+            $search = $request->query;
+            $query->where('full_name', 'like', "%{$search}%")
+                  ->orWhere('email', 'like', "%{$search}%");
+        }
+
+        $users = $query->limit(10)->get(['id', 'full_name', 'email']);
+
+        return response()->json([
+            'success' => true,
+            'data' => $users,
+        ]);
+    }
+}

--- a/backend/app/Http/Requests/StorePaperRequest.php
+++ b/backend/app/Http/Requests/StorePaperRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePaperRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Handled by middleware
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:300',
+            'abstract' => 'required|string|min:50',
+            'keywords' => 'nullable|string|max:500',
+            'research_area' => 'nullable|string|max:100',
+            'category' => 'nullable|string|max:100',
+            'authors' => 'nullable|string|max:500',
+            'google_scholar_url' => 'nullable|url|max:255|regex:/^https?:\/\/scholar\.google\.com\/.*/',
+            'doi' => 'nullable|string|max:100|regex:/^10\.\d{4,9}\/[-._;()\/:A-Z0-9]+$/i',
+            'publication_year' => 'nullable|integer|min:1900|max:' . date('Y'),
+            'research_area_id' => 'nullable|exists:research_areas,id',
+            'category_id' => 'nullable|exists:categories,id',
+            'department_id' => 'nullable|exists:departments,id',
+            'submission_status' => ['nullable', Rule::in(['draft', 'submitted'])],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'title.required' => 'The paper title is required.',
+            'abstract.required' => 'The paper abstract is required.',
+            'abstract.min' => 'The abstract must be at least 50 characters.',
+            'google_scholar_url.regex' => 'The Google Scholar URL must be a valid Google Scholar link (https://scholar.google.com/...)',
+            'doi.regex' => 'The DOI format is invalid. Expected format: 10.xxxx/xxxxx',
+            'publication_year.max' => 'The publication year cannot be in the future.',
+        ];
+    }
+}

--- a/backend/app/Http/Requests/UpdatePaperRequest.php
+++ b/backend/app/Http/Requests/UpdatePaperRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdatePaperRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Handled by middleware
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'sometimes|required|string|max:300',
+            'abstract' => 'sometimes|required|string|min:50',
+            'keywords' => 'nullable|string|max:500',
+            'research_area' => 'nullable|string|max:100',
+            'category' => 'nullable|string|max:100',
+            'authors' => 'nullable|string|max:500',
+            'google_scholar_url' => 'nullable|url|max:255|regex:/^https?:\/\/scholar\.google\.com\/.*/',
+            'doi' => 'nullable|string|max:100|regex:/^10\.\d{4,9}\/[-._;()\/:A-Z0-9]+$/i',
+            'publication_year' => 'nullable|integer|min:1900|max:' . date('Y'),
+            'research_area_id' => 'nullable|exists:research_areas,id',
+            'category_id' => 'nullable|exists:categories,id',
+            'department_id' => 'nullable|exists:departments,id',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'abstract.min' => 'The abstract must be at least 50 characters.',
+            'google_scholar_url.regex' => 'The Google Scholar URL must be a valid Google Scholar link (https://scholar.google.com/...)',
+            'doi.regex' => 'The DOI format is invalid. Expected format: 10.xxxx/xxxxx',
+        ];
+    }
+}

--- a/backend/app/Models/ActivityLog.php
+++ b/backend/app/Models/ActivityLog.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ActivityLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'action',
+        'entity_type',
+        'entity_id',
+        'old_values',
+        'new_values',
+        'ip_address',
+        'user_agent',
+    ];
+
+    protected $casts = [
+        'old_values' => 'array',
+        'new_values' => 'array',
+    ];
+
+    // Relationships
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    // Scopes
+    public function scopeRecent($query)
+    {
+        return $query->orderBy('created_at', 'desc');
+    }
+
+    public function scopeForUser($query, $userId)
+    {
+        return $query->where('user_id', $userId);
+    }
+}

--- a/backend/app/Models/Notification.php
+++ b/backend/app/Models/Notification.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Notification extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'sender_id',
+        'type',
+        'message',
+        'data',
+        'link',
+        'is_read',
+        'read_at',
+    ];
+
+    protected $casts = [
+        'data' => 'array',
+        'is_read' => 'boolean',
+        'read_at' => 'datetime',
+    ];
+
+    protected $attributes = [
+        'is_read' => false,
+    ];
+
+    // Relationships
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function sender()
+    {
+        return $this->belongsTo(User::class, 'sender_id');
+    }
+
+    // Scopes
+    public function scopeUnread($query)
+    {
+        return $query->where('is_read', false);
+    }
+
+    public function scopeRead($query)
+    {
+        return $query->where('is_read', true);
+    }
+
+    // Helper methods
+    public function markAsRead()
+    {
+        $this->update([
+            'is_read' => true,
+            'read_at' => now(),
+        ]);
+    }
+
+    public function markAsUnread()
+    {
+        $this->update([
+            'is_read' => false,
+            'read_at' => null,
+        ]);
+    }
+}

--- a/backend/app/Models/Project.php
+++ b/backend/app/Models/Project.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Project extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'research_area_id',
+        'supervisor_id',
+        'created_by',
+        'start_date',
+        'deadline',
+        'status',
+        'progress_pct',
+        'is_public',
+        'completed_at',
+    ];
+
+    protected $casts = [
+        'start_date' => 'date',
+        'deadline' => 'date',
+        'progress_pct' => 'integer',
+        'is_public' => 'boolean',
+        'completed_at' => 'datetime',
+    ];
+
+    protected $attributes = [
+        'status' => 'planning',
+        'progress_pct' => 0,
+        'is_public' => false,
+    ];
+
+    // Relationships
+    public function supervisor()
+    {
+        return $this->belongsTo(User::class, 'supervisor_id');
+    }
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function researchArea()
+    {
+        return $this->belongsTo(ResearchArea::class);
+    }
+
+    public function members()
+    {
+        return $this->hasMany(ProjectMember::class);
+    }
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class, 'project_members');
+    }
+
+    public function tasks()
+    {
+        return $this->hasMany(Task::class);
+    }
+
+    public function files()
+    {
+        return $this->hasMany(File::class);
+    }
+
+    public function comments()
+    {
+        return $this->morphMany(Comment::class, 'entity');
+    }
+
+    // Scopes
+    public function scopeActive($query)
+    {
+        return $query->whereIn('status', ['planning', 'in_progress']);
+    }
+
+    public function scopeCompleted($query)
+    {
+        return $query->where('status', 'completed');
+    }
+
+    // Accessors
+    public function getStatusColorAttribute()
+    {
+        $colors = [
+            'planning' => 'blue',
+            'in_progress' => 'yellow',
+            'completed' => 'green',
+            'archived' => 'gray',
+        ];
+        return $colors[$this->status] ?? 'gray';
+    }
+
+    public function getProgressAttribute()
+    {
+        return $this->progress_pct;
+    }
+}

--- a/backend/app/Models/ProjectMember.php
+++ b/backend/app/Models/ProjectMember.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ProjectMember extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'project_id',
+        'user_id',
+        'role',
+        'joined_at',
+        'left_at',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'joined_at' => 'datetime',
+        'left_at' => 'datetime',
+        'is_active' => 'boolean',
+    ];
+
+    protected $attributes = [
+        'role' => 'member',
+        'is_active' => true,
+    ];
+
+    // Relationships
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/ResearchPaper.php
+++ b/backend/app/Models/ResearchPaper.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Services\GoogleScholarService;
 
 class ResearchPaper extends Model
 {
@@ -51,7 +52,10 @@ class ResearchPaper extends Model
         'downloads' => 0,
     ];
 
-    // Relationships
+    // ============================================
+    // RELATIONSHIPS
+    // ============================================
+
     public function category()
     {
         return $this->belongsTo(Category::class);
@@ -97,7 +101,56 @@ class ResearchPaper extends Model
         return $this->hasMany(PaperVersion::class);
     }
 
-    // Scopes
+    // ============================================
+    // GOOGLE SCHOLAR METHODS
+    // ============================================
+
+    public function getScholarLinks(): array
+    {
+        $service = new GoogleScholarService();
+        return $service->getScholarLinks($this->google_scholar_url, $this->title);
+    }
+
+    public function getGoogleScholarLinkAttribute(): ?string
+    {
+        if ($this->google_scholar_url) {
+            return $this->google_scholar_url;
+        }
+
+        if ($this->title) {
+            $service = new GoogleScholarService();
+            return $service->generateSearchUrl($this->title);
+        }
+
+        return null;
+    }
+
+    public function getGoogleScholarSearchAttribute(): ?string
+    {
+        if ($this->title) {
+            $service = new GoogleScholarService();
+            return $service->generateSearchUrl($this->title);
+        }
+        return null;
+    }
+
+    public function hasExactScholarUrl(): bool
+    {
+        return !empty($this->google_scholar_url);
+    }
+
+    public function getDoiLinkAttribute(): ?string
+    {
+        if ($this->doi) {
+            return 'https://doi.org/' . $this->doi;
+        }
+        return null;
+    }
+
+    // ============================================
+    // SCOPES
+    // ============================================
+
     public function scopePending($query)
     {
         return $query->where('status', 'pending');
@@ -113,7 +166,27 @@ class ResearchPaper extends Model
         return $query->where('is_verified', true);
     }
 
-    // Accessors
+    /**
+     * Search papers by title or abstract
+     * (keywords and authors are relationships, not columns)
+     */
+    public function scopeSearch($query, string $search)
+    {
+        return $query->where(function ($q) use ($search) {
+            $q->where('title', 'LIKE', "%{$search}%")
+              ->orWhere('abstract', 'LIKE', "%{$search}%");
+        });
+    }
+
+    public function scopeSearchExact($query, string $title)
+    {
+        return $query->where('title', '=', $title);
+    }
+
+    // ============================================
+    // ACCESSORS
+    // ============================================
+
     public function getFormattedAuthorsAttribute()
     {
         return $this->authors->pluck('full_name')->implode(', ');
@@ -130,21 +203,8 @@ class ResearchPaper extends Model
         return $badges[$this->status] ?? 'secondary';
     }
 
-    // Helper method to get Google Scholar URL with proper format
-    public function getGoogleScholarLinkAttribute()
+    public function getScholarDataAttribute(): array
     {
-        if ($this->google_scholar_url) {
-            return $this->google_scholar_url;
-        }
-        return null;
-    }
-
-    // Helper method to get DOI link
-    public function getDoiLinkAttribute()
-    {
-        if ($this->doi) {
-            return 'https://doi.org/' . $this->doi;
-        }
-        return null;
+        return $this->getScholarLinks();
     }
 }

--- a/backend/app/Models/ResearchPaper.php
+++ b/backend/app/Models/ResearchPaper.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Services\GoogleScholarService;
+use App\Enums\PaperStatus;
 
 class ResearchPaper extends Model
 {
@@ -23,8 +24,10 @@ class ResearchPaper extends Model
         'publication_status',
         'category_id',
         'research_area_id',
+        'department_id',
         'uploaded_by',
         'verified_by',
+        'reviewed_by',
         'publication_year',
         'pdf_path',
         'pdf_filename',
@@ -34,11 +37,18 @@ class ResearchPaper extends Model
         'views',
         'downloads',
         'verified_at',
+        'submission_status',
+        'submitted_at',
+        'reviewed_at',
+        'rejection_reason',
+        'reviewer_notes',
     ];
 
     protected $casts = [
         'is_verified' => 'boolean',
         'verified_at' => 'datetime',
+        'submitted_at' => 'datetime',
+        'reviewed_at' => 'datetime',
         'publication_year' => 'integer',
         'file_size' => 'integer',
         'views' => 'integer',
@@ -50,6 +60,7 @@ class ResearchPaper extends Model
         'is_verified' => false,
         'views' => 0,
         'downloads' => 0,
+        'submission_status' => 'draft',
     ];
 
     // ============================================
@@ -66,6 +77,11 @@ class ResearchPaper extends Model
         return $this->belongsTo(ResearchArea::class);
     }
 
+    public function department()
+    {
+        return $this->belongsTo(Department::class);
+    }
+
     public function uploadedBy()
     {
         return $this->belongsTo(User::class, 'uploaded_by');
@@ -76,14 +92,25 @@ class ResearchPaper extends Model
         return $this->belongsTo(User::class, 'verified_by');
     }
 
+    public function reviewer()
+    {
+        return $this->belongsTo(User::class, 'reviewed_by');
+    }
+
     public function keywords()
     {
         return $this->belongsToMany(Keyword::class, 'paper_keywords');
     }
 
+    /**
+     * Authors relationship with proper foreign key
+     * Table: paper_authors
+     * Foreign key: paper_id (points to research_papers.id)
+     * Related key: user_id (points to users.id)
+     */
     public function authors()
     {
-        return $this->belongsToMany(User::class, 'paper_authors');
+        return $this->belongsToMany(User::class, 'paper_authors', 'paper_id', 'user_id');
     }
 
     public function comments()
@@ -148,7 +175,127 @@ class ResearchPaper extends Model
     }
 
     // ============================================
-    // SCOPES
+    // SUBMISSION METHODS
+    // ============================================
+
+    public function isDraft(): bool
+    {
+        return $this->submission_status === PaperStatus::DRAFT->value;
+    }
+
+    public function isSubmitted(): bool
+    {
+        return $this->submission_status === PaperStatus::SUBMITTED->value;
+    }
+
+    public function isUnderReview(): bool
+    {
+        return $this->submission_status === PaperStatus::UNDER_REVIEW->value;
+    }
+
+    public function isApproved(): bool
+    {
+        return $this->submission_status === PaperStatus::APPROVED->value;
+    }
+
+    public function isRejected(): bool
+    {
+        return $this->submission_status === PaperStatus::REJECTED->value;
+    }
+
+    public function isEditable(): bool
+    {
+        return $this->isDraft();
+    }
+
+    public function isSubmittable(): bool
+    {
+        return $this->isDraft();
+    }
+
+    public function submit(): bool
+    {
+        if (!$this->isSubmittable()) {
+            return false;
+        }
+
+        if (!$this->isComplete()) {
+            return false;
+        }
+
+        $this->submission_status = PaperStatus::SUBMITTED->value;
+        $this->submitted_at = now();
+        
+        return $this->save();
+    }
+
+    public function isComplete(): bool
+    {
+        return !empty($this->title) && 
+               !empty($this->abstract) && 
+               !empty($this->authors);
+    }
+
+    public function approve(int $reviewerId, ?string $notes = null): bool
+    {
+        if (!$this->isSubmitted() && !$this->isUnderReview()) {
+            return false;
+        }
+
+        $this->submission_status = PaperStatus::APPROVED->value;
+        $this->reviewed_by = $reviewerId;
+        $this->reviewed_at = now();
+        $this->reviewer_notes = $notes;
+        $this->status = 'approved';
+        $this->is_verified = true;
+        
+        return $this->save();
+    }
+
+    public function reject(int $reviewerId, string $reason, ?string $notes = null): bool
+    {
+        if (!$this->isSubmitted() && !$this->isUnderReview()) {
+            return false;
+        }
+
+        $this->submission_status = PaperStatus::REJECTED->value;
+        $this->reviewed_by = $reviewerId;
+        $this->reviewed_at = now();
+        $this->rejection_reason = $reason;
+        $this->reviewer_notes = $notes;
+        $this->status = 'rejected';
+        $this->is_verified = false;
+        
+        return $this->save();
+    }
+
+    public function returnToDraft(): bool
+    {
+        if (!$this->isRejected() && !$this->isSubmitted()) {
+            return false;
+        }
+
+        $this->submission_status = PaperStatus::DRAFT->value;
+        $this->submitted_at = null;
+        $this->reviewed_by = null;
+        $this->reviewed_at = null;
+        $this->rejection_reason = null;
+        
+        return $this->save();
+    }
+
+    public function getSubmissionStatusLabelAttribute(): string
+    {
+        return PaperStatus::tryFrom($this->submission_status)?->label() ?? 'Unknown';
+    }
+
+    public function getSubmissionStatusColorAttribute(): string
+    {
+        return PaperStatus::tryFrom($this->submission_status)?->color() ?? 'gray';
+    }
+
+    // ============================================
+    // SCOPES - STATUS (for the 'status' column)
     // ============================================
 
     public function scopePending($query)
@@ -156,7 +303,7 @@ class ResearchPaper extends Model
         return $query->where('status', 'pending');
     }
 
-    public function scopeApproved($query)
+    public function scopeStatusApproved($query)
     {
         return $query->where('status', 'approved');
     }
@@ -166,10 +313,6 @@ class ResearchPaper extends Model
         return $query->where('is_verified', true);
     }
 
-    /**
-     * Search papers by title or abstract
-     * (keywords and authors are relationships, not columns)
-     */
     public function scopeSearch($query, string $search)
     {
         return $query->where(function ($q) use ($search) {
@@ -181,6 +324,49 @@ class ResearchPaper extends Model
     public function scopeSearchExact($query, string $title)
     {
         return $query->where('title', '=', $title);
+    }
+
+    // ============================================
+    // SCOPES - SUBMISSION STATUS (for the 'submission_status' column)
+    // ============================================
+
+    public function scopeDrafts($query)
+    {
+        return $query->where('submission_status', PaperStatus::DRAFT->value);
+    }
+
+    public function scopeSubmitted($query)
+    {
+        return $query->where('submission_status', PaperStatus::SUBMITTED->value);
+    }
+
+    public function scopeUnderReview($query)
+    {
+        return $query->where('submission_status', PaperStatus::UNDER_REVIEW->value);
+    }
+
+    public function scopeSubmissionApproved($query)
+    {
+        return $query->where('submission_status', PaperStatus::APPROVED->value);
+    }
+
+    public function scopeRejected($query)
+    {
+        return $query->where('submission_status', PaperStatus::REJECTED->value);
+    }
+
+    public function scopeNeedsReview($query)
+    {
+        return $query->where('submission_status', PaperStatus::SUBMITTED->value)
+                     ->orWhere('submission_status', PaperStatus::UNDER_REVIEW->value);
+    }
+
+    public function scopeForUser($query, int $userId)
+    {
+        return $query->where('uploaded_by', $userId)
+                     ->orWhereHas('authors', function ($q) use ($userId) {
+                         $q->where('user_id', $userId);
+                     });
     }
 
     // ============================================

--- a/backend/app/Models/Task.php
+++ b/backend/app/Models/Task.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Task extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'project_id',
+        'assigned_to',
+        'created_by',
+        'name',
+        'description',
+        'priority',
+        'status',
+        'deadline',
+        'completed_at',
+    ];
+
+    protected $casts = [
+        'deadline' => 'date',
+        'completed_at' => 'datetime',
+    ];
+
+    protected $attributes = [
+        'priority' => 'medium',
+        'status' => 'pending',
+    ];
+
+    // Relationships
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function assignedTo()
+    {
+        return $this->belongsTo(User::class, 'assigned_to');
+    }
+
+    public function createdBy()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    // Scopes
+    public function scopePending($query)
+    {
+        return $query->where('status', 'pending');
+    }
+
+    public function scopeInProgress($query)
+    {
+        return $query->where('status', 'in_progress');
+    }
+
+    public function scopeCompleted($query)
+    {
+        return $query->where('status', 'completed');
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
@@ -18,6 +19,15 @@ class User extends Authenticatable
         'institution',
         'email',
         'password_hash',
+        'role_id',
+        'department_id',
+        'bio',
+        'research_interests',
+        'skills',
+        'profile_picture',
+        'is_active',
+        'last_login_at',
+        'email_verified_at',
     ];
 
     protected $hidden = [
@@ -30,6 +40,8 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password_hash' => 'hashed',
+            'is_active' => 'boolean',
+            'last_login_at' => 'datetime',
         ];
     }
 
@@ -40,6 +52,10 @@ class User extends Authenticatable
     {
         return $this->password_hash;
     }
+
+    // ============================================
+    // EXISTING RELATIONSHIPS
+    // ============================================
 
     /**
      * The user's assigned role.
@@ -66,5 +82,189 @@ class User extends Authenticatable
     public function roleVerification()
     {
         return $this->hasOne(RoleVerification::class);
+    }
+
+    // ============================================
+    // DASHBOARD RELATIONSHIPS (ADD THESE)
+    // ============================================
+
+    /**
+     * User's department
+     */
+    public function department()
+    {
+        return $this->belongsTo(Department::class);
+    }
+
+    /**
+     * Projects created by the user
+     */
+    public function createdProjects()
+    {
+        return $this->hasMany(Project::class, 'created_by');
+    }
+
+    /**
+     * Projects supervised by the user
+     */
+    public function supervisedProjects()
+    {
+        return $this->hasMany(Project::class, 'supervisor_id');
+    }
+
+    /**
+     * Project memberships
+     */
+    public function projectMemberships()
+    {
+        return $this->hasMany(ProjectMember::class);
+    }
+
+    /**
+     * Projects where user is a member
+     */
+    public function projectsAsMember()
+    {
+        return $this->belongsToMany(Project::class, 'project_members');
+    }
+
+    /**
+     * Tasks assigned to the user
+     */
+    public function tasks()
+    {
+        return $this->hasMany(Task::class, 'assigned_to');
+    }
+
+    /**
+     * Tasks created by the user
+     */
+    public function createdTasks()
+    {
+        return $this->hasMany(Task::class, 'created_by');
+    }
+
+    /**
+     * Papers uploaded by the user
+     */
+    public function papers()
+    {
+        return $this->hasMany(ResearchPaper::class, 'uploaded_by');
+    }
+
+    /**
+     * Papers authored by the user (many-to-many)
+     */
+    public function authoredPapers()
+    {
+        return $this->belongsToMany(ResearchPaper::class, 'paper_authors');
+    }
+
+    /**
+     * Notifications received by the user
+     */
+    public function notifications()
+    {
+        return $this->hasMany(Notification::class);
+    }
+
+    /**
+     * Unread notifications
+     */
+    public function unreadNotifications()
+    {
+        return $this->hasMany(Notification::class)->where('is_read', false);
+    }
+
+    /**
+     * Notifications sent by the user
+     */
+    public function sentNotifications()
+    {
+        return $this->hasMany(Notification::class, 'sender_id');
+    }
+
+    /**
+     * Activity logs for the user
+     */
+    public function activityLogs()
+    {
+        return $this->hasMany(ActivityLog::class);
+    }
+
+    /**
+     * Users who follow this user
+     */
+    public function followers()
+    {
+        return $this->belongsToMany(User::class, 'followers', 'followed_id', 'follower_id');
+    }
+
+    /**
+     * Users this user follows
+     */
+    public function following()
+    {
+        return $this->belongsToMany(User::class, 'followers', 'follower_id', 'followed_id');
+    }
+
+    // ============================================
+    // HELPER METHODS
+    // ============================================
+
+    /**
+     * Get total project count (as member + supervisor)
+     */
+    public function getProjectCountAttribute()
+    {
+        return $this->projectsAsMember()->count() + $this->supervisedProjects()->count();
+    }
+
+    /**
+     * Get total task count (assigned to user)
+     */
+    public function getTaskCountAttribute()
+    {
+        return $this->tasks()->where('status', '!=', 'completed')->count();
+    }
+
+    /**
+     * Get total paper count (uploaded by user)
+     */
+    public function getPaperCountAttribute()
+    {
+        return $this->papers()->count();
+    }
+
+    /**
+     * Get unread notification count
+     */
+    public function getNotificationCountAttribute()
+    {
+        return $this->unreadNotifications()->count();
+    }
+
+    /**
+     * Check if user is admin
+     */
+    public function isAdmin(): bool
+    {
+        return $this->role && $this->role->name === 'sys_admin';
+    }
+
+    /**
+     * Check if user is faculty
+     */
+    public function isFaculty(): bool
+    {
+        return $this->role && $this->role->name === 'faculty';
+    }
+
+    /**
+     * Check if user is student
+     */
+    public function isStudent(): bool
+    {
+        return $this->role && $this->role->name === 'student';
     }
 }

--- a/backend/app/Services/GoogleScholarService.php
+++ b/backend/app/Services/GoogleScholarService.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services;
+
+class GoogleScholarService
+{
+    /**
+     * Base URL for Google Scholar
+     */
+    private const BASE_URL = 'https://scholar.google.com/scholar';
+
+    /**
+     * Generate a Google Scholar search URL from a paper title
+     *
+     * @param string $title
+     * @return string
+     */
+    public function generateSearchUrl(string $title): string
+    {
+        // Clean and encode the title
+        $encodedTitle = $this->encodeTitle($title);
+
+        return self::BASE_URL . '?q=' . $encodedTitle;
+    }
+
+    /**
+     * Encode a title for Google Scholar search
+     * - URL encode spaces and special characters
+     * - Remove excessive whitespace
+     *
+     * @param string $title
+     * @return string
+     */
+    private function encodeTitle(string $title): string
+    {
+        // Trim whitespace
+        $title = trim($title);
+
+        // Replace multiple spaces with single space
+        $title = preg_replace('/\s+/', ' ', $title);
+
+        // URL encode
+        return urlencode($title);
+    }
+
+    /**
+     * Get the best available Google Scholar link for a paper
+     *
+     * @param string|null $exactUrl
+     * @param string|null $title
+     * @return array
+     */
+    public function getScholarLinks(?string $exactUrl, ?string $title): array
+    {
+        $result = [
+            'google_scholar_url' => null,
+            'google_scholar_search_url' => null,
+        ];
+
+        // If exact URL exists, use it
+        if ($exactUrl) {
+            $result['google_scholar_url'] = $exactUrl;
+        }
+
+        // Always generate a search URL if title exists
+        if ($title) {
+            $result['google_scholar_search_url'] = $this->generateSearchUrl($title);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Validate a Google Scholar URL
+     *
+     * @param string|null $url
+     * @return bool
+     */
+    public function isValidScholarUrl(?string $url): bool
+    {
+        if (empty($url)) {
+            return false;
+        }
+
+        // Must start with https://scholar.google.com/
+        if (!preg_match('/^https?:\/\/scholar\.google\.com\/.*/', $url)) {
+            return false;
+        }
+
+        // Must be a valid URL
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -17,11 +17,14 @@ return Application::configure(basePath: dirname(__DIR__))
             'admin' => \App\Http\Middleware\AdminMiddleware::class,
         ]);
 
+        // Fix: Return JSON for unauthenticated API requests
         $middleware->redirectGuestsTo(function (Request $request) {
-            if ($request->is('api/*')) {
-                return null;
+            if ($request->is('api/*') || $request->wantsJson()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Unauthenticated. Please log in.',
+                ], 401);
             }
-
             return '/login';
         });
     })

--- a/backend/database/migrations/2026_08_29_152245_add_submission_fields_to_research_papers_table.php
+++ b/backend/database/migrations/2026_08_29_152245_add_submission_fields_to_research_papers_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('research_papers', function (Blueprint $table) {
+            // Add submission status fields
+            $table->enum('submission_status', ['draft', 'submitted', 'under_review', 'approved', 'rejected'])
+                  ->default('draft')
+                  ->after('status');
+            
+            $table->timestamp('submitted_at')->nullable()->after('submission_status');
+            $table->timestamp('reviewed_at')->nullable()->after('submitted_at');
+            
+            $table->foreignId('reviewed_by')
+                  ->nullable()
+                  ->constrained('users')
+                  ->onDelete('set null')
+                  ->after('reviewed_at');
+            
+            $table->text('rejection_reason')->nullable()->after('reviewed_by');
+            $table->text('reviewer_notes')->nullable()->after('rejection_reason');
+            
+            // Add department_id (if not exists)
+            if (!Schema::hasColumn('research_papers', 'department_id')) {
+                $table->foreignId('department_id')
+                      ->nullable()
+                      ->constrained()
+                      ->onDelete('set null')
+                      ->after('research_area_id');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('research_papers', function (Blueprint $table) {
+            $table->dropForeign(['reviewed_by']);
+            $table->dropForeign(['department_id']);
+            
+            $table->dropColumn([
+                'submission_status',
+                'submitted_at',
+                'reviewed_at',
+                'reviewed_by',
+                'rejection_reason',
+                'reviewer_notes',
+                'department_id',
+            ]);
+        });
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -5,13 +5,20 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
+use App\Models\User;
+use App\Models\Project;
+use App\Models\ProjectMember;
+use App\Models\Task;
+use App\Models\Notification;
+use App\Models\ActivityLog;
 
 class DatabaseSeeder extends Seeder
 {
     public function run(): void
     {
-        // Seed Roles
+        // ============================================
+        // SEED ROLES
+        // ============================================
         $roles = [
             ['name' => 'student', 'display_name' => 'Student', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'faculty', 'display_name' => 'Faculty Member', 'created_at' => now(), 'updated_at' => now()],
@@ -20,7 +27,9 @@ class DatabaseSeeder extends Seeder
         ];
         DB::table('roles')->insert($roles);
 
-        // Seed Departments
+        // ============================================
+        // SEED DEPARTMENTS
+        // ============================================
         $departments = [
             ['name' => 'Computer Science', 'code' => 'CS', 'institution' => 'University of Technology', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'Software Engineering', 'code' => 'SE', 'institution' => 'University of Technology', 'created_at' => now(), 'updated_at' => now()],
@@ -29,7 +38,9 @@ class DatabaseSeeder extends Seeder
         ];
         DB::table('departments')->insert($departments);
 
-        // Seed Categories
+        // ============================================
+        // SEED CATEGORIES
+        // ============================================
         $categories = [
             ['name' => 'Journal Article', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'Conference Paper', 'created_at' => now(), 'updated_at' => now()],
@@ -40,7 +51,9 @@ class DatabaseSeeder extends Seeder
         ];
         DB::table('categories')->insert($categories);
 
-        // Seed Research Areas
+        // ============================================
+        // SEED RESEARCH AREAS
+        // ============================================
         $researchAreas = [
             ['name' => 'Artificial Intelligence', 'department_id' => 1, 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'Machine Learning', 'department_id' => 1, 'created_at' => now(), 'updated_at' => now()],
@@ -51,7 +64,9 @@ class DatabaseSeeder extends Seeder
         ];
         DB::table('research_areas')->insert($researchAreas);
 
-        // Seed Keywords
+        // ============================================
+        // SEED KEYWORDS
+        // ============================================
         $keywords = [
             ['name' => 'Deep Learning', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'Neural Networks', 'created_at' => now(), 'updated_at' => now()],
@@ -62,8 +77,12 @@ class DatabaseSeeder extends Seeder
         ];
         DB::table('keywords')->insert($keywords);
 
-        // Create admin user
-        DB::table('users')->insert([
+        // ============================================
+        // CREATE TEST USERS
+        // ============================================
+
+        // Admin User
+        $admin = User::create([
             'role_id' => 4,
             'department_id' => 1,
             'full_name' => 'System Admin',
@@ -79,8 +98,8 @@ class DatabaseSeeder extends Seeder
             'updated_at' => now(),
         ]);
 
-        // Create faculty user
-        DB::table('users')->insert([
+        // Faculty User
+        $faculty = User::create([
             'role_id' => 2,
             'department_id' => 1,
             'full_name' => 'Dr. John Smith',
@@ -96,8 +115,8 @@ class DatabaseSeeder extends Seeder
             'updated_at' => now(),
         ]);
 
-        // Create student user
-        DB::table('users')->insert([
+        // Student User
+        $student = User::create([
             'role_id' => 1,
             'department_id' => 1,
             'full_name' => 'Jane Doe',
@@ -112,5 +131,278 @@ class DatabaseSeeder extends Seeder
             'created_at' => now(),
             'updated_at' => now(),
         ]);
+
+        // ============================================
+        // CREATE PROJECTS
+        // ============================================
+
+        $projects = [
+            [
+                'title' => 'AI in Healthcare Research',
+                'description' => 'Research on AI applications in healthcare, focusing on diagnostic tools and patient care optimization.',
+                'supervisor_id' => $faculty->id,
+                'created_by' => $faculty->id,
+                'research_area_id' => 1,
+                'start_date' => now()->subMonths(2),
+                'deadline' => now()->addMonths(2),
+                'status' => 'in_progress',
+                'progress_pct' => 65,
+                'is_public' => true,
+                'created_at' => now()->subMonths(2),
+                'updated_at' => now(),
+            ],
+            [
+                'title' => 'NLP for Social Media Analysis',
+                'description' => 'Analyzing sentiment and trends in social media using advanced NLP techniques and transformer models.',
+                'supervisor_id' => $faculty->id,
+                'created_by' => $faculty->id,
+                'research_area_id' => 5,
+                'start_date' => now()->subMonths(1),
+                'deadline' => now()->addMonths(3),
+                'status' => 'planning',
+                'progress_pct' => 10,
+                'is_public' => true,
+                'created_at' => now()->subMonths(1),
+                'updated_at' => now(),
+            ],
+            [
+                'title' => 'Blockchain for Supply Chain Management',
+                'description' => 'Implementing blockchain technology to enhance traceability and transparency in supply chain management.',
+                'supervisor_id' => $faculty->id,
+                'created_by' => $student->id,
+                'research_area_id' => 6,
+                'start_date' => now()->subMonths(4),
+                'deadline' => now()->addMonths(1),
+                'status' => 'in_progress',
+                'progress_pct' => 80,
+                'is_public' => true,
+                'created_at' => now()->subMonths(4),
+                'updated_at' => now(),
+            ],
+            [
+                'title' => 'Data Mining in E-Commerce',
+                'description' => 'Analyzing customer behavior and improving recommendation systems using advanced data mining techniques.',
+                'supervisor_id' => $faculty->id,
+                'created_by' => $student->id,
+                'research_area_id' => 3,
+                'start_date' => now()->subMonths(6),
+                'deadline' => now()->subDays(10),
+                'status' => 'completed',
+                'progress_pct' => 100,
+                'is_public' => true,
+                'completed_at' => now()->subDays(10),
+                'created_at' => now()->subMonths(6),
+                'updated_at' => now()->subDays(10),
+            ],
+        ];
+
+        foreach ($projects as $projectData) {
+            $project = Project::create($projectData);
+
+            // Add supervisor as member
+            ProjectMember::create([
+                'project_id' => $project->id,
+                'user_id' => $faculty->id,
+                'role' => 'supervisor',
+                'joined_at' => now(),
+                'is_active' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            // Add student as member
+            ProjectMember::create([
+                'project_id' => $project->id,
+                'user_id' => $student->id,
+                'role' => 'member',
+                'joined_at' => now(),
+                'is_active' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        // ============================================
+        // CREATE TASKS
+        // ============================================
+
+        $projectIds = Project::pluck('id')->toArray();
+
+        $tasks = [
+            // Project 1 Tasks
+            [
+                'project_id' => $projectIds[0],
+                'assigned_to' => $student->id,
+                'created_by' => $faculty->id,
+                'name' => 'Literature Review',
+                'description' => 'Review existing literature on AI in healthcare, focusing on recent advances and challenges.',
+                'priority' => 'high',
+                'status' => 'completed',
+                'deadline' => now()->subDays(20),
+                'completed_at' => now()->subDays(15),
+                'created_at' => now()->subMonths(2),
+                'updated_at' => now()->subDays(15),
+            ],
+            [
+                'project_id' => $projectIds[0],
+                'assigned_to' => $student->id,
+                'created_by' => $faculty->id,
+                'name' => 'Data Collection',
+                'description' => 'Collect and preprocess healthcare datasets for AI model training and validation.',
+                'priority' => 'medium',
+                'status' => 'in_progress',
+                'deadline' => now()->addDays(10),
+                'created_at' => now()->subMonths(1),
+                'updated_at' => now(),
+            ],
+            [
+                'project_id' => $projectIds[0],
+                'assigned_to' => $student->id,
+                'created_by' => $faculty->id,
+                'name' => 'Model Training',
+                'description' => 'Train and evaluate AI models on preprocessed healthcare data.',
+                'priority' => 'high',
+                'status' => 'pending',
+                'deadline' => now()->addDays(30),
+                'created_at' => now()->subDays(5),
+                'updated_at' => now()->subDays(5),
+            ],
+            // Project 2 Tasks
+            [
+                'project_id' => $projectIds[1],
+                'assigned_to' => $student->id,
+                'created_by' => $faculty->id,
+                'name' => 'NLP Literature Review',
+                'description' => 'Review NLP techniques for social media sentiment analysis.',
+                'priority' => 'medium',
+                'status' => 'pending',
+                'deadline' => now()->addDays(15),
+                'created_at' => now()->subDays(2),
+                'updated_at' => now()->subDays(2),
+            ],
+            [
+                'project_id' => $projectIds[1],
+                'assigned_to' => $student->id,
+                'created_by' => $faculty->id,
+                'name' => 'Data Collection',
+                'description' => 'Collect social media datasets for analysis.',
+                'priority' => 'medium',
+                'status' => 'pending',
+                'deadline' => now()->addDays(20),
+                'created_at' => now()->subDays(1),
+                'updated_at' => now(),
+            ],
+            // Project 3 Tasks
+            [
+                'project_id' => $projectIds[2],
+                'assigned_to' => $student->id,
+                'created_by' => $faculty->id,
+                'name' => 'Final Report',
+                'description' => 'Write final project report and prepare presentation.',
+                'priority' => 'high',
+                'status' => 'pending',
+                'deadline' => now()->addDays(5),
+                'created_at' => now()->subDays(10),
+                'updated_at' => now()->subDays(10),
+            ],
+        ];
+
+        foreach ($tasks as $taskData) {
+            Task::create($taskData);
+        }
+
+        // ============================================
+        // CREATE NOTIFICATIONS
+        // ============================================
+
+        $notificationTypes = ['project_invite', 'task_assigned', 'task_completed', 'paper_uploaded', 'comment_added', 'project_updated'];
+
+        $notificationMessages = [
+            'You have been invited to join the project: AI in Healthcare Research',
+            'A new task has been assigned to you: Literature Review',
+            'Your task has been completed: Data Collection',
+            'A new paper has been uploaded to your project',
+            'Someone commented on your project: AI in Healthcare Research',
+            'Your project status has been updated',
+        ];
+
+        for ($i = 0; $i < 15; $i++) {
+            $isRead = $i < 5 ? false : true; // First 5 are unread
+            $index = array_rand($notificationTypes);
+
+            Notification::create([
+                'user_id' => $student->id,
+                'sender_id' => $faculty->id,
+                'type' => $notificationTypes[$index],
+                'message' => $notificationMessages[array_rand($notificationMessages)],
+                'data' => ['project_id' => $projectIds[array_rand($projectIds)]],
+                'link' => '/dashboard/projects',
+                'is_read' => $isRead,
+                'read_at' => $isRead ? now()->subDays(rand(1, 5)) : null,
+                'created_at' => now()->subDays(rand(1, 30)),
+                'updated_at' => now(),
+            ]);
+        }
+
+        // ============================================
+        // CREATE ACTIVITY LOGS
+        // ============================================
+
+        $actions = ['created', 'updated', 'viewed', 'uploaded', 'assigned', 'completed'];
+        $entities = ['project', 'paper', 'task', 'file', 'comment'];
+
+        $actionMessages = [
+            'created' => 'created a new',
+            'updated' => 'updated',
+            'viewed' => 'viewed',
+            'uploaded' => 'uploaded a',
+            'assigned' => 'assigned a',
+            'completed' => 'completed',
+        ];
+
+        for ($i = 0; $i < 25; $i++) {
+            $action = $actions[array_rand($actions)];
+            $entity = $entities[array_rand($entities)];
+
+            ActivityLog::create([
+                'user_id' => $student->id,
+                'action' => $action,
+                'entity_type' => $entity,
+                'entity_id' => rand(1, 10),
+                'old_values' => null,
+                'new_values' => ['description' => $actionMessages[$action] . ' ' . $entity],
+                'ip_address' => '127.0.0.1',
+                'user_agent' => 'Seeder/1.0',
+                'created_at' => now()->subDays(rand(1, 30)),
+                'updated_at' => now(),
+            ]);
+        }
+
+        // ============================================
+        // UPDATE USERS WITH ADDITIONAL DATA
+        // ============================================
+
+        // Update student with more research interests
+        $student->update([
+            'research_interests' => 'Natural Language Processing, Machine Learning, Deep Learning, Transformer Models',
+            'skills' => 'Python, PyTorch, TensorFlow, React, Laravel, Docker',
+            'bio' => 'PhD student in Computer Science at the University of Technology. Researching NLP applications in healthcare. Passionate about AI and its impact on society.',
+        ]);
+
+        // Update faculty with more details
+        $faculty->update([
+            'research_interests' => 'Artificial Intelligence, Machine Learning, Deep Learning, Healthcare AI, NLP',
+            'skills' => 'Python, R, MATLAB, Research Methodology, Grant Writing, Project Management',
+            'bio' => 'Professor of Computer Science with 15 years of experience. Published over 50 papers in top-tier journals. Research focuses on AI applications in healthcare and NLP.',
+        ]);
+
+        $this->command->info('✅ Database seeded successfully!');
+        $this->command->info('📊 Created projects, tasks, notifications, and activity logs.');
+        $this->command->info('👤 Test users:');
+        $this->command->info('   - admin@scholaros.com (System Admin)');
+        $this->command->info('   - faculty@scholaros.com (Faculty)');
+        $this->command->info('   - student@scholaros.com (Student)');
+        $this->command->info('🔑 All passwords: password');
+        $this->command->info('📚 4 projects, 6 tasks, 15 notifications, 25 activity logs created.');
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -173,6 +173,15 @@ Route::prefix('v1')->group(function () {
         );
 
         // ------------------------------------------------------------
+        // ⭐ NEW: SEARCH PAPERS
+        // GET /api/v1/papers/search?q=title&exact=true
+        // ------------------------------------------------------------
+        Route::get(
+            '/search',
+            [ResearchPaperController::class, 'search']
+        );
+
+        // ------------------------------------------------------------
         // GET SINGLE PAPER
         // GET /api/v1/papers/{id}
         // ------------------------------------------------------------
@@ -211,7 +220,7 @@ Route::prefix('v1')->group(function () {
     });
 
     // ========================================================================
-    // DASHBOARD ROUTES (ADD THESE)
+    // DASHBOARD ROUTES
     // ========================================================================
 
     // All dashboard routes require authentication

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Api\ProjectController;
 use App\Http\Controllers\Api\PaperController;
 use App\Http\Controllers\Api\ResearcherController;
 use App\Http\Controllers\Api\NotificationController;
+use App\Http\Controllers\Api\PaperSubmissionController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -173,7 +174,7 @@ Route::prefix('v1')->group(function () {
         );
 
         // ------------------------------------------------------------
-        // ⭐ NEW: SEARCH PAPERS
+        // SEARCH PAPERS
         // GET /api/v1/papers/search?q=title&exact=true
         // ------------------------------------------------------------
         Route::get(
@@ -216,6 +217,57 @@ Route::prefix('v1')->group(function () {
                 '/{id}',
                 [ResearchPaperController::class, 'destroy']
             );
+        });
+    });
+
+    // ========================================================================
+    // PAPER SUBMISSIONS (NEW)
+    // ========================================================================
+
+    Route::prefix('submissions')->group(function () {
+
+        // ------------------------------------------------------------
+        // AUTHENTICATED USER ROUTES
+        // ------------------------------------------------------------
+        
+        Route::middleware('auth:sanctum')->group(function () {
+            
+            // GET /api/v1/submissions - Get user's papers
+            Route::get('/', [PaperSubmissionController::class, 'index']);
+            
+            // POST /api/v1/submissions - Create draft
+            Route::post('/', [PaperSubmissionController::class, 'store']);
+            
+            // GET /api/v1/submissions/{id} - Get single paper
+            Route::get('/{id}', [PaperSubmissionController::class, 'show']);
+            
+            // PUT /api/v1/submissions/{id} - Update draft
+            Route::put('/{id}', [PaperSubmissionController::class, 'update']);
+            
+            // DELETE /api/v1/submissions/{id} - Delete paper (draft or rejected only)
+            Route::delete('/{id}', [PaperSubmissionController::class, 'destroy']);
+            
+            // POST /api/v1/submissions/{id}/submit - Submit for approval
+            Route::post('/{id}/submit', [PaperSubmissionController::class, 'submit']);
+        });
+        
+        // ------------------------------------------------------------
+        // ADMIN ROUTES (Review & Approve)
+        // ------------------------------------------------------------
+        
+        Route::middleware(['auth:sanctum', 'admin'])->group(function () {
+            
+            // GET /api/v1/submissions/review - Get papers for review
+            Route::get('/review', [PaperSubmissionController::class, 'reviewIndex']);
+            
+            // POST /api/v1/submissions/{id}/approve - Approve paper
+            Route::post('/{id}/approve', [PaperSubmissionController::class, 'approve']);
+            
+            // POST /api/v1/submissions/{id}/reject - Reject paper
+            Route::post('/{id}/reject', [PaperSubmissionController::class, 'reject']);
+            
+            // POST /api/v1/submissions/{id}/return-to-draft - Return to draft
+            Route::post('/{id}/return-to-draft', [PaperSubmissionController::class, 'returnToDraft']);
         });
     });
 

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,11 @@ use App\Http\Controllers\Api\ResearchPaperController;
 use App\Http\Controllers\Api\ResearchAreaController;
 use App\Http\Controllers\Api\RoleVerificationController;
 use App\Http\Controllers\Api\Admin\VerificationController;
+use App\Http\Controllers\Api\DashboardController;
+use App\Http\Controllers\Api\ProjectController;
+use App\Http\Controllers\Api\PaperController;
+use App\Http\Controllers\Api\ResearcherController;
+use App\Http\Controllers\Api\NotificationController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -17,7 +22,6 @@ use Illuminate\Support\Facades\Route;
 | Versioned application routes are under /api/v1/*
 |
 */
-
 
 // ============================================================================
 // AUTHENTICATION ROUTES
@@ -51,7 +55,6 @@ Route::middleware('auth:sanctum')->group(function () {
     });
 });
 
-
 // ============================================================================
 // VERSION 1 API ROUTES
 // ============================================================================
@@ -70,7 +73,6 @@ Route::prefix('v1')->group(function () {
             'timestamp' => now()->toISOString()
         ]);
     });
-
 
     // ========================================================================
     // ADMIN VERIFICATION
@@ -115,7 +117,6 @@ Route::prefix('v1')->group(function () {
             );
         });
 
-
     // ========================================================================
     // RESEARCH AREAS
     // ========================================================================
@@ -133,7 +134,6 @@ Route::prefix('v1')->group(function () {
         '/research-areas',
         [ResearchAreaController::class, 'store']
     );
-
 
     // ========================================================================
     // ROLE VERIFICATION
@@ -157,7 +157,6 @@ Route::prefix('v1')->group(function () {
         );
     });
 
-
     // ========================================================================
     // RESEARCH PAPERS
     // ========================================================================
@@ -173,7 +172,6 @@ Route::prefix('v1')->group(function () {
             [ResearchPaperController::class, 'index']
         );
 
-
         // ------------------------------------------------------------
         // GET SINGLE PAPER
         // GET /api/v1/papers/{id}
@@ -182,7 +180,6 @@ Route::prefix('v1')->group(function () {
             '/{id}',
             [ResearchPaperController::class, 'show']
         );
-
 
         // ------------------------------------------------------------
         // PROTECTED PAPER ROUTES
@@ -213,25 +210,75 @@ Route::prefix('v1')->group(function () {
         });
     });
 
+    // ========================================================================
+    // DASHBOARD ROUTES (ADD THESE)
+    // ========================================================================
+
+    // All dashboard routes require authentication
+    Route::middleware('auth:sanctum')->prefix('dashboard')->group(function () {
+
+        // ------------------------------------------------------------
+        // STATISTICS
+        // GET /api/v1/dashboard/stats
+        // ------------------------------------------------------------
+        Route::get('/stats', [DashboardController::class, 'stats']);
+
+        // ------------------------------------------------------------
+        // RECENT ACTIVITY
+        // GET /api/v1/dashboard/recent-activity
+        // ------------------------------------------------------------
+        Route::get('/recent-activity', [DashboardController::class, 'recentActivity']);
+
+        // ------------------------------------------------------------
+        // PROJECTS
+        // ------------------------------------------------------------
+        Route::get('/projects', [ProjectController::class, 'index']);
+        Route::get('/projects/{id}', [ProjectController::class, 'show']);
+        Route::post('/projects', [ProjectController::class, 'store']);
+
+        // ------------------------------------------------------------
+        // PAPERS
+        // ------------------------------------------------------------
+        Route::get('/papers', [PaperController::class, 'index']);
+        Route::get('/papers/stats', [PaperController::class, 'stats']);
+
+        // ------------------------------------------------------------
+        // RESEARCHERS
+        // ------------------------------------------------------------
+        Route::get('/researchers', [ResearcherController::class, 'index']);
+        Route::get('/researchers/{id}', [ResearcherController::class, 'show']);
+        Route::get('/researchers/search', [ResearcherController::class, 'search']);
+
+        // ------------------------------------------------------------
+        // NOTIFICATIONS
+        // ------------------------------------------------------------
+        Route::get('/notifications', [NotificationController::class, 'index']);
+        Route::get('/notifications/count', [NotificationController::class, 'count']);
+        Route::put('/notifications/{id}/read', [NotificationController::class, 'markAsRead']);
+        Route::put('/notifications/mark-all-read', [NotificationController::class, 'markAllAsRead']);
+        Route::delete('/notifications/{id}', [NotificationController::class, 'destroy']);
+    });
 
     // ========================================================================
     // VERSIONED USER PROFILE
     // ========================================================================
 
     // GET /api/v1/user
-   Route::middleware('auth:sanctum')->get(
-    '/user',
-    function (Request $request) {
-        $user = $request->user()->load([
-            'role',
-            'researchAreas',
-        ]);
+    Route::middleware('auth:sanctum')->get(
+        '/user',
+        function (Request $request) {
+            $user = $request->user()->load([
+                'role',
+                'researchAreas',
+                'department',
+                'projectsAsMember',
+                'supervisedProjects',
+            ]);
 
-        return response()->json([
-            'success' => true,
-            'data' => $user,
-        ]);
-    }
-);
-
+            return response()->json([
+                'success' => true,
+                'data' => $user,
+            ]);
+        }
+    );
 });


### PR DESCRIPTION
What's Added:
- Paper submission workflow: Draft → Submitted → Under Review → Approved/Rejected
- Create, update, and delete drafts
- Submit papers for approval with validation
- Admin review endpoints (approve/reject with notes)
- Return rejected/submitted papers to draft

### Models & Enums:
- ResearchPaper: Added submission methods, scopes, and relationships
- PaperStatus: New enum for submission status (draft, submitted, under_review, approved, rejected)

### Controllers:
- PaperSubmissionController: Complete CRUD + submission + review workflow

### Routes:
- /api/v1/submissions - User endpoints (CRUD, submit)
- /api/v1/submissions/review - Admin review endpoints

### Security:
- Users can only edit their own drafts
- Only admins can approve/reject papers
- Papers must be complete before submission
- Only drafts can be edited or submitted

### API Endpoints:
- GET    /api/v1/submissions - Get user's papers
- POST   /api/v1/submissions - Create draft
- GET    /api/v1/submissions/{id} - Get single paper
- PUT    /api/v1/submissions/{id} - Update draft
- DELETE /api/v1/submissions/{id} - Delete paper (draft/rejected only)
- POST   /api/v1/submissions/{id}/submit - Submit for approval
- GET    /api/v1/submissions/review - Get papers for review (admin)
- POST   /api/v1/submissions/{id}/approve - Approve paper (admin)
- POST   /api/v1/submissions/{id}/reject - Reject paper (admin)
- POST   /api/v1/submissions/{id}/return-to-draft - Return to draft (admin)

closes #65 